### PR TITLE
Fix: Gatsby plugin for Styled Components

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -14,6 +14,7 @@ module.exports = {
         path: `${__dirname}/src/images`,
       },
     },
+    `gatsby-plugin-styled-components`,
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
     `gatsby-plugin-remove-trailing-slashes`,


### PR DESCRIPTION
This pull request fixes the styled components not being "server-side rendered" upon the first paint.